### PR TITLE
Merge in formatting/link fixes from Claude Code

### DIFF
--- a/R/fct_formats.R
+++ b/R/fct_formats.R
@@ -36,7 +36,7 @@
 #'
 #' CAMPAIGN_COMMENT: Additional notes or comments about the campaign (optional)
 #'
-#' See `vignette("campaign-data")` for more information.
+#' See `vignette("campaign_data")` for more information.
 #'
 #' @return A tibble with 0 rows and standardised campaign columns
 #' @family initialise_tibble
@@ -93,6 +93,8 @@ initialise_campaign_tibble <- function() {
 #'
 #' BIOTA_COMMENT: Additional notes or comments about the biological sample (optional)
 #'
+#' See `vignette("biota_data")` for more information.
+#'
 #' @return A tibble with 0 rows and standardised biota columns
 #' @family initialise_tibble
 #' @family biota
@@ -134,6 +136,8 @@ initialise_biota_tibble <- function() {
 #'
 #' MEASURED_CATEGORY: Measurement context (External Media, Internal to Organism, Surface of Organism)
 #'
+#' See `vignette("compartments_data")` for more information.
+#'
 #' @return A tibble with 0 rows and standardised compartment columns
 #' @family initialise_tibble
 #' @family compartment
@@ -164,6 +168,8 @@ initialise_compartments_tibble <- function() {
 #' PROTOCOL_NAME: Standardised name of the protocol
 #'
 #' PROTOCOL_COMMENT: Additional notes or details about the protocol
+#'
+#' See `vignette("methods_data")` for more information.
 #'
 #' @return A tibble with 0 rows and standardised methods columns
 #' @family initialise_tibble
@@ -208,6 +214,8 @@ initialise_methods_tibble <- function() {
 #' ENTERED_BY: Person or entity who entered the parameter
 #'
 #' PARAMETER_COMMENT: Additional notes about the parameter
+#'
+#' See `vignette("parameters_data")` for more information.
 #'
 #' @return A tibble with 0 rows and standardised parameter columns
 #' @family initialise_tibble
@@ -274,6 +282,8 @@ initialise_parameters_tibble <- function() {
 #'
 #' REF_COMMENT: Additional notes about the reference
 #'
+#' See `vignette("references_data")` for more information.
+#'
 #' @return A tibble with 0 rows and standardised reference columns
 #' @family initialise_tibble
 #' @family reference
@@ -333,6 +343,8 @@ initialise_references_tibble <- function() {
 #'
 #' SAMPLE_ID: Unique identifier for the sample (Key)
 #'
+#' See `vignette("samples_data")` for more information.
+#'
 #' @return A tibble with 0 rows and standardised sample columns
 #' @family initialise_tibble
 #' @family sample
@@ -390,6 +402,8 @@ initialise_samples_tibble <- function() {
 #' ENTERED_DATE: Date when the site data was entered
 #'
 #' SITE_COMMENT: Additional notes about the site
+#'
+#' See `vignette("sites_data")` for more information.
 #'
 #' @return A tibble with 0 rows and standardised site columns
 #' @family initialise_tibble
@@ -479,6 +493,8 @@ initialise_sites_tibble <- function() {
 #'
 #' MEASUREMENT_COMMENT: Additional notes about the measurement
 #'
+#' See `vignette("measurements_data")` for more information.
+#'
 #' @return A tibble with 0 rows and standardised measurement columns
 #' @family initialise_tibble
 #' @family measurement
@@ -539,6 +555,8 @@ initialise_measurements_tibble <- function() {
 #'
 #' GOLD_RELEVANCE: Relevance score at gold standard level
 #'
+#' See `vignette("CREED_scores_data")` for more information.
+#'
 #' @return A tibble with 0 rows and standardised CREED columns
 #' @family initialise_tibble
 #' @family CREED
@@ -577,6 +595,8 @@ initialise_CREED_scores_tibble <- function() {
 #' score: Assessment score for the criterion
 #'
 #' limitations: Identified limitations or concerns for the criterion
+#'
+#' See `vignette("CREED_data")` for more information.
 #'
 #' @return A tibble with 0 rows and standardised CREED criterion columns
 #' @family initialise_tibble

--- a/README.md
+++ b/README.md
@@ -10,22 +10,23 @@ This format is a (first) attempt to address this issue. Rather than attempt a pe
 
 ## Tables
 
-Tables are created as `tibble::tibble()` calls with empty variables of specific types (e.g. `character(0)` for strings). These support easier validation (see [Validation](validation.html)) and the extensive Tidyverse family of functions.
+Tables are created as `tibble::tibble()` calls with empty variables of specific types (e.g. `character(0)` for strings). These support easier validation (see [Validation](https://NIVANorge.github.io/eDataDRF/articles/validation.html)) and the extensive Tidyverse family of functions.
 
 Tables are listed below:
 
 | Table Name | Purpose | Comments |
 |---|---|---|
-| Campaign | Records data about sampling campaign and organisation collecting data. | |
-| Reference | Records conventional publication metadata, where available | |
-| Sites | Records site coordinates, land use, country/ocean | |
-| Parameters | Records data on stressors (chemical, radiation, etc.), quality measurements | |
-| Compartments | Records information on the compartment/matrix sampled | |
-| Samples | Records which combinations of dates, sites, parameters and compartments were sampled | Not used in final analysis, but exists as an intermediate table used to create measurements |
-| Biota | Where relevant, records biota species, tissue, life stage, and gender | Optional |
-| Methods | Records type and descriptions of methods used for sampling, extraction, fractionation and analysis | |
-| Measurements | Records measured values, units, uncertainty, sample size, and methods associated with a given sample | |
-| CREED (quality) | Records assessment purpose statement, relevant data summarised from above tables, relevance/reliability scores, and final assessment of data quality. | |
+| [Campaign](https://NIVANorge.github.io/eDataDRF/articles/campaign_data.html) | Records data about sampling campaign and organisation collecting data. | |
+| [Reference](https://NIVANorge.github.io/eDataDRF/articles/references_data.html) | Records conventional publication metadata, where available | |
+| [Sites](https://NIVANorge.github.io/eDataDRF/articles/sites_data.html) | Records site coordinates, land use, country/ocean | |
+| [Parameters](https://NIVANorge.github.io/eDataDRF/articles/parameters_data.html) | Records data on stressors (chemical, radiation, etc.), quality measurements | |
+| [Compartments](https://NIVANorge.github.io/eDataDRF/articles/compartments_data.html) | Records information on the compartment/matrix sampled | |
+| [Samples](https://NIVANorge.github.io/eDataDRF/articles/samples_data.html) | Records which combinations of dates, sites, parameters and compartments were sampled | Not used in final analysis, but exists as an intermediate table used to create measurements |
+| [Biota](https://NIVANorge.github.io/eDataDRF/articles/biota_data.html) | Where relevant, records biota species, tissue, life stage, and gender | Optional |
+| [Methods](https://NIVANorge.github.io/eDataDRF/articles/methods_data.html) | Records type and descriptions of methods used for sampling, extraction, fractionation and analysis | |
+| [Measurements](https://NIVANorge.github.io/eDataDRF/articles/measurements_data.html) | Records measured values, units, uncertainty, sample size, and methods associated with a given sample | |
+| [CREED (quality)](https://NIVANorge.github.io/eDataDRF/articles/CREED_data.html) | Records assessment purpose statement, relevant data summarised from above tables, relevance/reliability scores, and final assessment of data quality. | |
+| [CREED Scores](https://NIVANorge.github.io/eDataDRF/articles/CREED_scores_data.html) | [description needed] | |
 
 : Table of tables in the eData format, their purpose, and comments.
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -7,6 +7,27 @@ navbar:
     left: [intro, reference, articles, news]
     right: [search, github, lightswitch]
 
+articles:
+- title: "Data tables"
+  desc: "Format and variables for each table in the eData DRF"
+  contents:
+  - campaign_data
+  - references_data
+  - sites_data
+  - parameters_data
+  - compartments_data
+  - samples_data
+  - biota_data
+  - methods_data
+  - measurements_data
+- title: "CREED quality assessment"
+  desc: "Format and scoring for data quality assessment"
+  contents:
+  - CREED_data
+  - CREED_scores_data
+- title: "Other"
+  contents:
+  - validation
 
 reference:
 - title: Initialise tibbles

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,0 +1,4 @@
+/* Widen the Articles dropdown to prevent long article names from being truncated */
+.navbar .dropdown-menu {
+  min-width: 220px;
+}

--- a/vignettes/CREED_data.qmd
+++ b/vignettes/CREED_data.qmd
@@ -24,34 +24,34 @@ library(eDataDRF)
 initialise_CREED_data_tibble()
 ```
 
-## Variables
+# Variables
 
-# Criterion ID - String, free, mandatory
+## Criterion ID - String, free, mandatory
 `criterion_id`
 
 <!-- Unique identifier for the CREED criterion. -->
 
-# Criterion Title - String, free, mandatory
+## Criterion Title - String, free, mandatory
 `criterion_title`
 
 <!-- Descriptive title of the criterion. -->
 
-# Required Recommended - String, free, mandatory
+## Required Recommended - String, free, mandatory
 `required_recommended`
 
 <!-- Whether the criterion is required or recommended. -->
 
-# Relevant Data - String, free, mandatory
+## Relevant Data - String, free, mandatory
 `relevant_data`
 
 <!-- Data or information relevant to assessing the criterion. -->
 
-# Score - String, free, mandatory
+## Score - String, free, mandatory
 `score`
 
 <!-- Assessment score for the criterion. -->
 
-# Limitations - String, free, mandatory
+## Limitations - String, free, mandatory
 `limitations`
 
 <!-- Identified limitations or concerns for the criterion. -->

--- a/vignettes/CREED_scores_data.qmd
+++ b/vignettes/CREED_scores_data.qmd
@@ -23,29 +23,29 @@ library(eDataDRF)
 initialise_CREED_scores_tibble()
 ```
 
-## Variables
+# Variables
 
-# Reference ID - String, free, mandatory
+## Reference ID - String, free, mandatory
 `REFERENCE_ID`
 
 <!-- Unique identifier linking to the references table. Foreign key. -->
 
-# Silver Reliability - String, free, mandatory
+## Silver Reliability - String, free, mandatory
 `SILVER_RELIABILITY`
 
 <!-- Reliability score at silver standard level. -->
 
-# Silver Relevance - String, free, mandatory
+## Silver Relevance - String, free, mandatory
 `SILVER_RELEVANCE`
 
 <!-- Relevance score at silver standard level. -->
 
-# Gold Reliability - String, free, mandatory
+## Gold Reliability - String, free, mandatory
 `GOLD_RELIABILITY`
 
 <!-- Reliability score at gold standard level. -->
 
-# Gold Relevance - String, free, mandatory
+## Gold Relevance - String, free, mandatory
 `GOLD_RELEVANCE`
 
 <!-- Relevance score at gold standard level. -->

--- a/vignettes/biota_data.qmd
+++ b/vignettes/biota_data.qmd
@@ -30,24 +30,24 @@ library(eDataDRF)
 initialise_biota_tibble()
 ```
 
-## Variables
+# Variables
 
-# Sample ID - String, free, mandatory
+## Sample ID - String, free, mandatory
 `SAMPLE_ID`
 
 <!-- Unique identifier linking to the samples table. Foreign key for measurements. -->
 
-# Site Code - String, free, mandatory
+## Site Code - String, free, mandatory
 `SITE_CODE`
 
 <!-- Code identifying the sampling location. Foreign key for sites. -->
 
-# Parameter Name - String, free, mandatory
+## Parameter Name - String, free, mandatory
 `PARAMETER_NAME`
 
 <!-- Name of the measured parameter or stressor. Foreign key for parameters. -->
 
-# Environ Compartment - String, controlled, mandatory
+## Environ Compartment - String, controlled, mandatory
 `ENVIRON_COMPARTMENT`
 
 <!-- Broad environmental compartment category. Inherited from the samples table. -->
@@ -58,11 +58,11 @@ initialise_biota_tibble()
 environ_compartments_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from environ_compartments_vocabulary() output. -->
 
-# Environ Compartment Sub - String, controlled, mandatory
+## Environ Compartment Sub - String, controlled, mandatory
 `ENVIRON_COMPARTMENT_SUB`
 
 <!-- Specific sub-category of the environmental compartment. Inherited from the samples table. -->
@@ -73,11 +73,11 @@ environ_compartments_vocabulary()
 environ_compartments_sub_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from environ_compartments_sub_vocabulary() output. -->
 
-# Measured Category - String, controlled, mandatory
+## Measured Category - String, controlled, mandatory
 `MEASURED_CATEGORY`
 
 <!-- Category indicating measurement context. Inherited from the samples table. -->
@@ -88,21 +88,21 @@ environ_compartments_sub_vocabulary()
 measured_categories_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from measured_categories_vocabulary() output. -->
 
-# Sampling Date - String, free, mandatory
+## Sampling Date - String, free, mandatory
 `SAMPLING_DATE`
 
 <!-- Date when the biological sample was collected. Inherited from the samples table. -->
 
-# Subsample - String, free, mandatory
+## Subsample - String, free, mandatory
 `SUBSAMPLE`
 
 <!-- Identifier for subsample or replicate. Inherited from the samples table. -->
 
-# Species Group - String, controlled, mandatory
+## Species Group - String, controlled, mandatory
 `SPECIES_GROUP`
 
 <!-- Taxonomic group classification, e.g., Fish, Molluscs, Plants. -->
@@ -113,11 +113,11 @@ measured_categories_vocabulary()
 species_groups_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from species_groups_vocabulary() output. -->
 
-# Sample Species - String, controlled, mandatory
+## Sample Species - String, controlled, mandatory
 `SAMPLE_SPECIES`
 
 <!-- Scientific binomial name of the sampled species. -->
@@ -128,11 +128,11 @@ species_groups_vocabulary()
 species_names_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from species_names_vocabulary() output. -->
 
-# Sample Tissue - String, controlled, mandatory
+## Sample Tissue - String, controlled, mandatory
 `SAMPLE_TISSUE`
 
 <!-- Type of biological tissue sampled. -->
@@ -143,11 +143,11 @@ species_names_vocabulary()
 tissue_types_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from tissue_types_vocabulary() output. -->
 
-# Sample Species Lifestage - String, controlled, mandatory
+## Sample Species Lifestage - String, controlled, mandatory
 `SAMPLE_SPECIES_LIFESTAGE`
 
 <!-- Life stage of the organism at sampling. -->
@@ -158,11 +158,11 @@ tissue_types_vocabulary()
 lifestage_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from lifestage_vocabulary() output. -->
 
-# Sample Species Gender - String, controlled, mandatory
+## Sample Species Gender - String, controlled, mandatory
 `SAMPLE_SPECIES_GENDER`
 
 <!-- Gender or sex of the sampled organism. -->
@@ -173,11 +173,11 @@ lifestage_vocabulary()
 gender_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from gender_vocabulary() output. -->
 
-# Biota Comment - String, free, optional
+## Biota Comment - String, free, optional
 `BIOTA_COMMENT`
 
 <!-- Additional notes or comments about the biological sample. -->

--- a/vignettes/compartments_data.qmd
+++ b/vignettes/compartments_data.qmd
@@ -28,14 +28,14 @@ library(eDataDRF)
 initialise_compartments_tibble()
 ```
 
-## Variables
+# Variables
 
-# Environmental Compartment - String, controlled, mandatory
+## Environmental Compartment - String, controlled, mandatory
 `ENVIRON_COMPARTMENT`
 
 Identifies which of the earth's spheres the sample originated from: aquatic (hydrosphere), air (atmospheric), terrestrial (geosphere), or biota (biosphere). Although largely comprehensive, it's possible that some samples may not fit well into this category. 
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 ```{r}
 #| label: environ_compartment
@@ -43,12 +43,12 @@ Identifies which of the earth's spheres the sample originated from: aquatic (hyd
 environ_compartments_vocabulary()
 ```
 
-# Environmental Sub-Compartment - String, controlled, mandatory
+## Environmental Sub-Compartment - String, controlled, mandatory
 `ENVIRON_COMPARTMENT_SUB`
 
 Environmental compartments have been sub-divided into a series of subcompartments. No taxonomy or ontology was consulted in creation of this controlled vocabulary, although soil subcompartments were based on the [World Reference Base for Soil Resources](https://isric.org/explore/wrb).   
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 ```{r}
 #| label: environ_compartment_sub
@@ -56,12 +56,12 @@ Environmental compartments have been sub-divided into a series of subcompartment
 environ_compartments_sub_vocabulary()
 ```
 
-# Measured Category - String, controlled, mandatory
+## Measured Category - String, controlled, mandatory
 `MEASURED_CATEGORY`
 
 <!-- Measurement context (External Media, Internal to Organism, Surface of Organism). -->
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 ```{r}
 #| label: measured_category

--- a/vignettes/measurements_data.qmd
+++ b/vignettes/measurements_data.qmd
@@ -24,24 +24,24 @@ library(eDataDRF)
 initialise_measurements_tibble()
 ```
 
-## Variables
+# Variables
 
-# Site Code - String, free, mandatory
+## Site Code - String, free, mandatory
 `SITE_CODE`
 
 <!-- Code identifying the sampling location. -->
 
-# Parameter Name - String, free, mandatory
+## Parameter Name - String, free, mandatory
 `PARAMETER_NAME`
 
 <!-- Name of the measured parameter. Foreign key for parameters. -->
 
-# Sampling Date - String, free, mandatory
+## Sampling Date - String, free, mandatory
 `SAMPLING_DATE`
 
 <!-- Date of sample collection. -->
 
-# Environ Compartment Sub - String, controlled, mandatory
+## Environ Compartment Sub - String, controlled, mandatory
 `ENVIRON_COMPARTMENT_SUB`
 
 <!-- Specific environmental sub-compartment. -->
@@ -52,16 +52,16 @@ initialise_measurements_tibble()
 environ_compartments_sub_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from environ_compartments_sub_vocabulary() output. -->
 
-# Subsample - String, free, mandatory
+## Subsample - String, free, mandatory
 `SUBSAMPLE`
 
 <!-- Subsample identifier. -->
 
-# Measured Flag - String, controlled, mandatory
+## Measured Flag - String, controlled, mandatory
 `MEASURED_FLAG`
 
 <!-- Quality flag for the measurement (e.g., < LOQ, < LOD). -->
@@ -72,16 +72,16 @@ environ_compartments_sub_vocabulary()
 measured_flags_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from measured_flags_vocabulary() output. -->
 
-# Measured Value - Numeric, free, mandatory
+## Measured Value - Numeric, free, mandatory
 `MEASURED_VALUE`
 
 <!-- Numeric value of the measurement. -->
 
-# Uncertainty Type - String, controlled, mandatory
+## Uncertainty Type - String, controlled, mandatory
 `UNCERTAINTY_TYPE`
 
 <!-- Type of uncertainty or variability metric. -->
@@ -92,21 +92,21 @@ measured_flags_vocabulary()
 uncertainty_types_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from uncertainty_types_vocabulary() output. -->
 
-# Uncertainty Upper - Numeric, free, mandatory
+## Uncertainty Upper - Numeric, free, mandatory
 `UNCERTAINTY_UPPER`
 
 <!-- Upper bound of uncertainty. -->
 
-# Uncertainty Lower - Numeric, free, mandatory
+## Uncertainty Lower - Numeric, free, mandatory
 `UNCERTAINTY_LOWER`
 
 <!-- Lower bound of uncertainty. -->
 
-# Measured Unit - String, controlled, mandatory
+## Measured Unit - String, controlled, mandatory
 `MEASURED_UNIT`
 
 <!-- Unit of measurement. -->
@@ -117,21 +117,21 @@ uncertainty_types_vocabulary()
 parameter_unit_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from parameter_unit_vocabulary() output. -->
 
-# Measured N - Numeric, free, mandatory
+## Measured N - Numeric, free, mandatory
 `MEASURED_N`
 
 <!-- Number of replicates or observations. -->
 
-# LOQ Value - Numeric, free, mandatory
+## LOQ Value - Numeric, free, mandatory
 `LOQ_VALUE`
 
 <!-- Limit of quantification value. -->
 
-# LOQ Unit - String, controlled, mandatory
+## LOQ Unit - String, controlled, mandatory
 `LOQ_UNIT`
 
 <!-- Unit for the limit of quantification. -->
@@ -142,16 +142,16 @@ parameter_unit_vocabulary()
 parameter_unit_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from parameter_unit_vocabulary() output. -->
 
-# LOD Value - Numeric, free, mandatory
+## LOD Value - Numeric, free, mandatory
 `LOD_VALUE`
 
 <!-- Limit of detection value. -->
 
-# LOD Unit - String, controlled, mandatory
+## LOD Unit - String, controlled, mandatory
 `LOD_UNIT`
 
 <!-- Unit for the limit of detection. -->
@@ -162,11 +162,11 @@ parameter_unit_vocabulary()
 parameter_unit_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from parameter_unit_vocabulary() output. -->
 
-# Sampling Protocol - String, controlled, mandatory
+## Sampling Protocol - String, controlled, mandatory
 `SAMPLING_PROTOCOL`
 
 <!-- Protocol used for sample collection. Foreign key for methods. -->
@@ -177,11 +177,11 @@ parameter_unit_vocabulary()
 sampling_protocols_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from sampling_protocols_vocabulary() output. -->
 
-# Extraction Protocol - String, controlled, mandatory
+## Extraction Protocol - String, controlled, mandatory
 `EXTRACTION_PROTOCOL`
 
 <!-- Protocol used for sample extraction. Foreign key for methods. -->
@@ -192,11 +192,11 @@ sampling_protocols_vocabulary()
 extraction_protocols_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from extraction_protocols_vocabulary() output. -->
 
-# Fractionation Protocol - String, controlled, mandatory
+## Fractionation Protocol - String, controlled, mandatory
 `FRACTIONATION_PROTOCOL`
 
 <!-- Protocol used for sample fractionation. Foreign key for methods. -->
@@ -207,11 +207,11 @@ extraction_protocols_vocabulary()
 fractionation_protocols_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from fractionation_protocols_vocabulary() output. -->
 
-# Analytical Protocol - String, controlled, mandatory
+## Analytical Protocol - String, controlled, mandatory
 `ANALYTICAL_PROTOCOL`
 
 <!-- Protocol used for analysis. Foreign key for methods. -->
@@ -222,26 +222,26 @@ fractionation_protocols_vocabulary()
 analytical_protocols_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from analytical_protocols_vocabulary() output. -->
 
-# Reference ID - String, free, mandatory
+## Reference ID - String, free, mandatory
 `REFERENCE_ID`
 
 <!-- Reference identifier for the data source. Foreign key for references. -->
 
-# Sample ID - String, free, mandatory
+## Sample ID - String, free, mandatory
 `SAMPLE_ID`
 
 <!-- Unique sample identifier. -->
 
-# Campaign Name Short - String, free, mandatory
+## Campaign Name Short - String, free, mandatory
 `CAMPAIGN_NAME_SHORT`
 
 <!-- Short name of the associated campaign. -->
 
-# Environ Compartment - String, controlled, mandatory
+## Environ Compartment - String, controlled, mandatory
 `ENVIRON_COMPARTMENT`
 
 <!-- Broad environmental compartment. -->
@@ -252,11 +252,11 @@ analytical_protocols_vocabulary()
 environ_compartments_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from environ_compartments_vocabulary() output. -->
 
-# Parameter Type - String, controlled, mandatory
+## Parameter Type - String, controlled, mandatory
 `PARAMETER_TYPE`
 
 <!-- Classification of the parameter. -->
@@ -267,11 +267,11 @@ environ_compartments_vocabulary()
 parameter_types_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from parameter_types_vocabulary() output. -->
 
-# Measured Type - String, controlled, mandatory
+## Measured Type - String, controlled, mandatory
 `MEASURED_TYPE`
 
 <!-- Type of measurement. -->
@@ -282,11 +282,11 @@ parameter_types_vocabulary()
 measured_types_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from measured_types_vocabulary() output. -->
 
-# Measurement Comment - String, free, optional
+## Measurement Comment - String, free, optional
 `MEASUREMENT_COMMENT`
 
 <!-- Additional notes about the measurement. -->

--- a/vignettes/methods_data.qmd
+++ b/vignettes/methods_data.qmd
@@ -37,9 +37,9 @@ library(eDataDRF)
 initialise_methods_tibble()
 ```
 
-## Variables
+# Variables
 
-# Protocol ID - String, free, mandatory
+## Protocol ID - String, free, mandatory
 `PROTOCOL_ID`
 
 A short, terse identifier for the protocol. This is used as a primary key for Methods data and a foreign key in the Sampling Protocol, Extraction Protocol, Fractionation Protocol, and Analytical Protocol columns.  [Measurements data](measurements_data.html). 
@@ -57,12 +57,12 @@ generate_protocol_id(
 )
 ```
 
-# Campaign Name - String, free, mandatory
+## Campaign Name - String, free, mandatory
 `CAMPAIGN_NAME`
 
 A short, terse identifier for the campaign. Foreign key referenced from [Campaign data](campaign_data.html), used to generate [Protocol ID](#protocol-id---string-free-mandatory).
 
-# Protocol Category - String, controlled vocabulary, mandatory
+## Protocol Category - String, controlled vocabulary, mandatory
 `PROTOCOL_CATEGORY`
 
 The category of protocol/method (Sampling, Extraction, Fractionation, Analytical).
@@ -73,7 +73,7 @@ The category of protocol/method (Sampling, Extraction, Fractionation, Analytical
 protocol_categories_vocabulary()
 ```
 
-# Protocol Name - String, controlled vocabulary, mandatory
+## Protocol Name - String, controlled vocabulary, mandatory
 `PROTOCOL_NAME`
 
 The consensus name (short and long) of a protocol or method used in sampling. Options are currently based on the aquatic ecotoxicology domain, but will be extended and harmonised with relevant ontologies and taxonomies as practical.
@@ -84,7 +84,7 @@ The consensus name (short and long) of a protocol or method used in sampling. Op
 protocol_options_vocabulary()
 ```
 
-# Protocol Comment - String, free, optional
+## Protocol Comment - String, free, optional
 `PROTOCOL_COMMENT`
 
 Space for the recording of any additional notes or comments about the method deemed relevant. As information on the specific equipment or more detailed protocols may also be useful, users are encouraged to copy relevant text verbatim from the source.

--- a/vignettes/parameters_data.qmd
+++ b/vignettes/parameters_data.qmd
@@ -28,14 +28,14 @@ initialise_parameters_tibble()
 
 It is expected that most relevant studies will be collecting data on chemical pollutants in the environment. Non-chemicals are accomodated by the format, but they cannot necessarily be as well-characterised as chemicals, where we are able to take advantage of the high-quality infrastructure developed by chemists. 
 
-## Variables
+# Variables
 
-# Parameter Type - String, controlled, mandatory
+## Parameter Type - String, controlled, mandatory
 `PARAMETER_TYPE`
 
 Parameter type is divided into five classifications and two missing data values. This classification requires a degree of subjective judgement. What makes a chemical a stressor versus a quality parameter is not always clear. However, we anticipate that in most cases this will be uncontroversial. Where this is not the case stressors can still be identified by name/id.
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 ```{r}
 #| label: parameter_type
@@ -51,12 +51,12 @@ parameter_types_vocabulary()
 `"Ecological Indicator"` - Parameter is an indicator or metric of ecological concern.
 `"Other"` - Parameter belongs to another category. Please note in comments field.
 
-# Parameter Sub-type - String, controlled, mandatory
+## Parameter Sub-type - String, controlled, mandatory
 `PARAMETER_TYPE_SUB`
 
 Parameter Sub-type is a further subdivision of [Parameter Type]. The majority of subtypes are chemical classifications from the [ChemOnt/ClassyFire](https://pmc.ncbi.nlm.nih.gov/articles/PMC5096306/) chemical taxonomy; other subtypes are intended for use with quality parameters, stressors measured as mixtures, or other cases where additional details are needed.
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 ```{r}
 #| label: parameter_sub_type
@@ -64,12 +64,12 @@ Parameter Sub-type is a further subdivision of [Parameter Type]. The majority of
 parameter_types_sub_vocabulary()
 ```
 
-# Parameter Name, controlled, mandatory
+## Parameter Name, controlled, mandatory
 `PARAMETER_NAME`
 
 Parameter name records the reported name of a measured parameter. In the majority of cases 
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 ```{r}
 #| label: parameter_name
@@ -82,5 +82,5 @@ dummy_parameters_vocabulary() |> dplyr::slice_head(n = 10)
 - We use whatever ClassyFire gives us, I think
 - Currently used as a primary key - this will be replaced with a better system once we get it working
 
-# Parameter Sub-Name
+## Parameter Sub-Name
 `PARAMETER_NAME_SUB`

--- a/vignettes/references_data.qmd
+++ b/vignettes/references_data.qmd
@@ -28,9 +28,9 @@ initialise_references_tibble()
 reference_character_limits()
 ```
 
-## Variables
+# Variables
 
-# Reference ID - String, auto-generated, mandatory
+## Reference ID - String, auto-generated, mandatory
 `REFERENCE_ID`
 
 The reference's primary key, automatically generated from YEAR, AUTHOR, and TITLE using `generate_reference_id()`, as follows:
@@ -46,84 +46,84 @@ The reference's primary key, automatically generated from YEAR, AUTHOR, and TITL
 
 Reference ID is also a foreign key in [Measurement data](measurements_data.html). 
 
-# Reference Type - String, controlled, mandatory
+## Reference Type - String, controlled, mandatory
 `REFERENCE_TYPE`
 
 <!-- Type of publication (Journal Article, Report, Dataset, etc.). -->
 
-# Author - String, free, mandatory
+## Author - String, free, mandatory
 `AUTHOR`
 
 The full authors list from the referenced object, formatted as `Lastname1, Firstname1; Lastname2, Firstname2; etc.`. 
 
-# Title - String, free, mandatory
+## Title - String, free, mandatory
 `TITLE`
 
 The title of the publication or document.
 
-# Year - Integer, free, mandatory
+## Year - Integer, free, mandatory
 `YEAR`
 
 The year of publication or the most recent update to the referenced object. 
 
-# Access Date - Date (ISO), free, mandatory
+## Access Date - Date (ISO), free, mandatory
 `ACCESS_DATE`
 
 The ISO date when the referenced object was accessed.
 
-# Journal Name - String, free, conditional on reference type
+## Journal Name - String, free, conditional on reference type
 `PERIODICAL_JOURNAL`
 
 The name of the journal or periodical a journal article was published in. Conditionally mandatory if [Reference Type](#reference-type---string-controlled-mandatory) is `Journal Article`.
 
-# Volume - Numeric, free, optional
+## Volume - Numeric, free, optional
 `VOLUME`
 
 The volume of a named journal an article was published in. Optional.
 
-# Issue - Numeric, free, optional
+## Issue - Numeric, free, optional
 `ISSUE`
 
 The issue of a named journal an article was published in. Optional.
 
-# Publisher - String, free, conditional on reference type
+## Publisher - String, free, conditional on reference type
 `PUBLISHER`
 
 The publisher of a reference object. Conditionally mandatory if [Reference Type](#reference-type---string-controlled-mandatory) is `Book` or `Report`.
 
-# Institution - String, free, conditional on reference type
+## Institution - String, free, conditional on reference type
 `INSTITUTION`
 
 The primary instition responsible for a referenced object. Conditionally mandatory if [Reference Type](#reference-type---string-controlled-mandatory) is `Report`.
 
-# DOI - String, free, optional
+## DOI - String, free, optional
 `DOI`
 
 If available, the Digital Object Identifier associated with a reference object. Optional, but the preferred identifier when avaiable. 
 
 See the website of the [doi Foundation](https://www.doi.org/) for more information.
 
-# URL - String, free, optional
+## URL - String, free, optional
 `URL`
 
 A Uniform Resource Locator (URL, i.e. web address) linking to the referenced object, if available. Optional.
 
-# ISBN ISSN - String, free, optional
+## ISBN ISSN - String, free, optional
 `ISBN_ISSN`
 
 An International Standard Book Number (ISBN, 10 or 13 digits) or International Standard Serial Number (ISSN, 8 digits) associated with a book or periodical. Optional.
 
-# Edition - String, free, optional
+## Edition - String, free, optional
 `EDITION`
 
 The edition of a referenced object, if relevant. Optional.
 
-# Document Number - String, free, optional
+## Document Number - String, free, optional
 `DOCUMENT_NUMBER`
 
 A document or report number, typically available for reports and other official documents. Optional.
 
-# Reference Comment - String, free, optional
+## Reference Comment - String, free, optional
 `REF_COMMENT`
 
 Space for the recording of any additional notes or comments about the reference deemed relevant. 

--- a/vignettes/samples_data.qmd
+++ b/vignettes/samples_data.qmd
@@ -24,24 +24,24 @@ library(eDataDRF)
 initialise_samples_tibble()
 ```
 
-## Variables
+# Variables
 
-# Site Code - String, free, mandatory
+## Site Code - String, free, mandatory
 `SITE_CODE`
 
 <!-- Code identifying the sampling location. -->
 
-# Site Name - String, free, mandatory
+## Site Name - String, free, mandatory
 `SITE_NAME`
 
 <!-- Descriptive name of the sampling site. -->
 
-# Parameter Name - String, free, mandatory
+## Parameter Name - String, free, mandatory
 `PARAMETER_NAME`
 
 <!-- Name of the measured parameter. -->
 
-# Parameter Type - String, controlled, mandatory
+## Parameter Type - String, controlled, mandatory
 `PARAMETER_TYPE`
 
 <!-- Classification of the parameter. -->
@@ -52,11 +52,11 @@ initialise_samples_tibble()
 parameter_types_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from parameter_types_vocabulary() output. -->
 
-# Environ Compartment - String, controlled, mandatory
+## Environ Compartment - String, controlled, mandatory
 `ENVIRON_COMPARTMENT`
 
 <!-- Environmental compartment defined as one of the earth's spheres (aquatic, atmospheric, etc.). -->
@@ -67,11 +67,11 @@ parameter_types_vocabulary()
 environ_compartments_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from environ_compartments_vocabulary() output. -->
 
-# Environ Compartment Sub - String, controlled, mandatory
+## Environ Compartment Sub - String, controlled, mandatory
 `ENVIRON_COMPARTMENT_SUB`
 
 <!-- Sub-divisions of environmental compartments into water body types, soil profile, etc. -->
@@ -82,11 +82,11 @@ environ_compartments_vocabulary()
 environ_compartments_sub_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from environ_compartments_sub_vocabulary() output. -->
 
-# Measured Category - String, controlled, mandatory
+## Measured Category - String, controlled, mandatory
 `MEASURED_CATEGORY`
 
 <!-- Measurement context category. -->
@@ -97,26 +97,26 @@ environ_compartments_sub_vocabulary()
 measured_categories_vocabulary()
 ```
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 <!-- Fill in from measured_categories_vocabulary() output. -->
 
-# Sampling Date - String, free, mandatory
+## Sampling Date - String, free, mandatory
 `SAMPLING_DATE`
 
 <!-- Date of sample collection. -->
 
-# Subsample - String, free, mandatory
+## Subsample - String, free, mandatory
 `SUBSAMPLE`
 
 <!-- Subsample or replicate identifier. -->
 
-# Subsample ID - String, free, mandatory
+## Subsample ID - String, free, mandatory
 `SUBSAMPLE_ID`
 
 <!-- Unique identifier for the subsample. -->
 
-# Sample ID - String, free, mandatory
+## Sample ID - String, free, mandatory
 `SAMPLE_ID`
 
 <!-- Unique identifier for the sample. Key field. -->

--- a/vignettes/sites_data.qmd
+++ b/vignettes/sites_data.qmd
@@ -28,21 +28,21 @@ library(eDataDRF)
 initialise_sites_tibble()
 ```
 
-## Variables
+# Variables
 
-# Site Code - String, free, mandatory
+## Site Code - String, free, mandatory
 `SITE_CODE`
 
 A short, unique code identifying the sampled site. Although formatting is not enforced on this field, we recommend using an abbreviated combination of the campaign, long form site name and any details relevant to the site. For example:
 
 "Arctic Monitoring Program; Pelagic Sampling Point 37" -> `AMP-Pelagic-37`. The site code is the primary key for sites data and is used as a foreign key in [samples](samples_data.html) and [measurements](measurements_data.html).
 
-# Site Name - String, free, mandatory
+## Site Name - String, free, mandatory
 `SITE_NAME`
 
 A longer form name of the site, potentially including details such as address, region, site type, etc. May be fully copied from source to enable easy tracing back of the relevant details. 
 
-# Site Geographic Feature - String, controlled, mandatory
+## Site Geographic Feature - String, controlled, mandatory
 `SITE_GEOGRAPHIC_FEATURE`
 
 Categorisation of site type allows for broad comparisons to be made. Site Geographic feature is based on a variety of existing land-use taxonomy to facilitate conversion and comparison:
@@ -77,7 +77,7 @@ These are summarised in the table below
 | Other | Specify details in [SITE_COMMENT](#site-comment---string-free-optional) | | | | |
 
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 ```{r}
 #| label: site_geographic_feature
@@ -85,12 +85,12 @@ These are summarised in the table below
 geographic_features_vocabulary()
 ```
 
-# Site Geographic Feature Sub - String, controlled, mandatory
+## Site Geographic Feature Sub - String, controlled, mandatory
 `SITE_GEOGRAPHIC_FEATURE_SUB`
 
 In some cases geographic feature vocabulary may not have enough resolution to capture sampling sites. For example, in bodies of water, it may be important to distinguish between samples from the benthos, water column, water surface, etc. In this case, sub-features can be used to add additional precision. 
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 ```{r}
 #| label: site_geographic_feature_sub
@@ -98,12 +98,12 @@ In some cases geographic feature vocabulary may not have enough resolution to ca
 geographic_features_sub_vocabulary()
 ```
 
-# ISO Country  - String, controlled, mandatory
+## ISO Country  - String, controlled, mandatory
 `COUNTRY_ISO`
 
 Although the sheer size of countries makes them at times poor identifiers of geographical location, they remain useful data. Although this variable is marked as mandatory, it is possible to enter "Not relevant" when sites are out of the territory of any nation (e.g. in international waters). The [ISO 3166 set of country codes](https://www.iso.org/iso-3166-country-codes.html) is used, via the R package `{iso}`.
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 ```{r}
 #| label: country_iso
@@ -111,14 +111,14 @@ Although the sheer size of countries makes them at times poor identifiers of geo
 countries_vocabulary()
 ```
 
-# IHO Ocean/Sea - String, controlled, mandatory
+## IHO Ocean/Sea - String, controlled, mandatory
 `OCEAN_IHO`
 
 As with countries, oceans are not necessarily the best geographical identifiers, but they provide useful, human-readable data for understanding sampling sites. The [International Hydrographic Organisation's version 3 Sea Areas](https://doi.org/10.14284/323) dataset is used to provide a reasonably-standardised set of names for seas and oceans. As with [Country](#iso-country---string-controlled-mandatory), Ocean is mandatory but should be marked as "Not relevant" when the site is on land.
 
 Where sampling sites are located in national territory but also in or near (intentionally vague) an ocean or sea, we recommend recording both variables.
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 ```{r}
 #| label: ocean_iho
@@ -126,24 +126,24 @@ Where sampling sites are located in national territory but also in or near (inte
 areas_vocabulary()
 ```
 
-# Latitude - Numeric, free, mandatory
+## Latitude - Numeric, free, mandatory
 `LATITUDE`
 
 Site latitude (north-south position, also known as northing, between -90.0° and +90.0°) is recorded in decimal decimal degrees. Arbitrary precision (within the bounds of R's numeric data type) is possible, but the degree of precision reported (i.e. decimal places) should be appropriate to the actual sampling. 3 decimal places corresponds to approximately 111 m accuracy, and 4 to within 11 m. Under some circumstances this can cause somewhat confusing combinations of coordinates and site types; for example, a site may be reported as being on land but with coordinates that are clearly in the ocean. In future, we plan to include an explicit metric of spatial uncertainty. A latitude is always associated with a [Coordinate Reference System](#coordinate-reference-system---string-controlled-mandatory).
 
-# Longitude - Numeric, free, mandatory
+## Longitude - Numeric, free, mandatory
 `LONGITUDE`
 
 Site longitude (east-west position, also known as easting, between -180.0° and +180.0°) is recorded in decimal decimal degrees. See [Latitude](#latitude---numeric-free-mandatory) for further details. A longitude is always associated with a [Coordinate Reference System](#coordinate-reference-system---string-controlled-mandatory).
 
-# Coordinate Reference System - String, controlled, mandatory
+## Coordinate Reference System - String, controlled, mandatory
 `SITE_COORDINATE_SYSTEM`
 
 A site's latitude and longitude are calculated using a reference system "placed" at a given point on the globe and parameterised within a given region. This Coordinate Reference System is a necessary component of any geographical coordinate data. In most global datasets, the World Geodetic System, 1984 version (WGS 84) is used. However, national or other local datasets may use a variety of CRS, such as the Universal Transverse Mercator (UTM), which projects the Earth into a series of square or rectangular zones; in this case, it is necessary to know the CRS and the grid number. 
 
 This controlled vocabulary uses the package `{crsuggest}`, which in turn uses the EPSG Dataset v10.019, (product of the International Association of Oil & Gas Producers, [terms of use](https://epsg.org/terms-of-use.html)). However, because the full 6000+ CRS included would be impractically large for the associated UI, we filter this down to a small set of systems relevant to the test cases used with the format so far. In future, CRS metadata will be used to automatically filter available CRS based on the desired geographical scope.
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 ```{r}
 #| label: site_coordinate_system
@@ -151,17 +151,17 @@ This controlled vocabulary uses the package `{crsuggest}`, which in turn uses th
 coordinate_systems_vocabulary(common_only = TRUE)
 ```
 
-# Altitude Value - Numeric, free, mandatory
+## Altitude Value - Numeric, free, mandatory
 `ALTITUDE_VALUE`
 
 Altitude value above or below sea level, including depth of water sampling (but *not* depth of ice or sediment cores). This data is frequently not available for sampling sites, in which case it can be reported as 0. Associated with an [altitude unit](#altitude-unit---string-controlled-mandatory).
 
-# Altitude Unit - String, controlled, mandatory
+## Altitude Unit - String, controlled, mandatory
 `ALTITUDE_UNIT`
 
 Unit associated with [altitude value](#altitude-value---numeric-free-mandatory).
 
-## Controlled Vocabulary
+### Controlled Vocabulary
 
 ```{r}
 #| label: altitude_unit
@@ -169,17 +169,17 @@ Unit associated with [altitude value](#altitude-value---numeric-free-mandatory).
 altitude_units_vocabulary()
 ```
 
-# Entered By - String, free, mandatory
+## Entered By - String, free, mandatory
 `ENTERED_BY`
 
 The name or email address of the user entering data.
 
-# Entered Date - Date (ISO), free, mandatory
+## Entered Date - Date (ISO), free, mandatory
 `ENTERED_DATE`
 
 The date that site data were entered.
 
-# Site Comment - String, free, optional
+## Site Comment - String, free, optional
 `SITE_COMMENT`
 
 Space for the recording of any additional notes or comments about the site deemed relevant, particularly any operations performed by the user on sites data, such as merging sites, converting a sampling region to a discrete point, or estimating point coordinates from a map.


### PR DESCRIPTION
No changes to text content.

- Fix heading hierarchy in 9 vignettes to match campaign_data.qmd reference pattern: ## Variables -> # Variables, # [Field] -> ## [Field], ## CV -> ### Controlled Vocabulary
- Fix broken vignette() link in fct_formats.R: campaign-data -> campaign_data
- Add See `vignette("X_data")` Roxygen links to 10 initialise_*_tibble functions
- Add absolute URL links to all data table names in README.md table
- Fix broken Validation link in README.md (relative -> absolute URL)
- Split CREED row into two rows (CREED data + CREED Scores) in README.md table
- Add articles: section to _pkgdown.yml to order vignettes per README table
- Add pkgdown/extra.css to widen Articles dropdown (min-width: 220px)