### PR TITLE
Claude pass picked up some typos, broken links, etc.

### DIFF
--- a/R/fct_formats.R
+++ b/R/fct_formats.R
@@ -435,7 +435,7 @@ initialise_sites_tibble <- function() {
   )
 }
 
-#' Initialise an 26x0 tibble for storing mmeasurement data
+#' Initialise an 26x0 tibble for storing measurement data
 #'
 #' Creates an empty tibble with the standardised column structure for measurements data.
 #'

--- a/R/fct_generate_IDs.R
+++ b/R/fct_generate_IDs.R
@@ -74,7 +74,7 @@ abbreviate_string <- function(
 }
 
 #' Generate a semi-unique string ID for a protocol based on its type,
-#' name, the campaign name, and a sequence number; used a a key between Methods
+#' name, the campaign name, and a sequence number; used as a key between Methods
 #' and Measurements table.
 #'
 #' @description

--- a/README.qmd
+++ b/README.qmd
@@ -13,7 +13,7 @@ prefer-html: true
 
 # eData Data Reporting Format
 
-The eData Data Reporting Format is a format for the reporting of chemical occurence/exposure data in the natural environment. It provides tables, vocabulary, and validation functions for structuring chemical occurence data, as well as spatial, social, biological, geographical, and other metadata.
+The eData Data Reporting Format is a format for the reporting of chemical occurrence/exposure data in the natural environment. It provides tables, vocabulary, and validation functions for structuring chemical occurrence data, as well as spatial, social, biological, geographical, and other metadata.
 
 # Installation
 
@@ -59,7 +59,7 @@ Tables are listed below:
 
 ## Vocabulary
 
-Likewise, controlled vocabulary is available as functions that return vectors, lists, or tables. In some cases, helper functions are available that wrap multiple invididual functions.
+Likewise, controlled vocabulary is available as functions that return vectors, lists, or tables. In some cases, helper functions are available that wrap multiple individual functions.
 
 Where external data sources are used to generate a vocabulary, functions may wrap (processed) data from other R packages or load raw data from external sources. Vocabulary functions are documented in the [Reference section](reference/index.html#controlled-vocabulary) and linked to in the relevant table files in 
 

--- a/man/generate_protocol_id.Rd
+++ b/man/generate_protocol_id.Rd
@@ -3,7 +3,7 @@
 \name{generate_protocol_id}
 \alias{generate_protocol_id}
 \title{Generate a semi-unique string ID for a protocol based on its type,
-name, the campaign name, and a sequence number; used a a key between Methods
+name, the campaign name, and a sequence number; used as a key between Methods
 and Measurements table.}
 \usage{
 generate_protocol_id(

--- a/man/initialise_measurements_tibble.Rd
+++ b/man/initialise_measurements_tibble.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/fct_formats.R
 \name{initialise_measurements_tibble}
 \alias{initialise_measurements_tibble}
-\title{Initialise an 26x0 tibble for storing mmeasurement data}
+\title{Initialise an 26x0 tibble for storing measurement data}
 \usage{
 initialise_measurements_tibble()
 }

--- a/tests/testthat/test-fct_formats.R
+++ b/tests/testthat/test-fct_formats.R
@@ -1,4 +1,4 @@
-# tests/testthat/test-initialise_functions.R ----
+# tests/testthat/test-fct_formats.R ----
 
 # Test Tibble Initialisation Functions ----
 

--- a/vignettes/CREED_data.qmd
+++ b/vignettes/CREED_data.qmd
@@ -16,7 +16,7 @@ knitr:
 [Criteria for Reporting and Evaluating Exposure Datasets (CREED)](https://www.setac.org/resource/creed-for-use-in-environmental-assessments-a-timely-development-update.html) is a framework for evaluating the relevance and reliability of a reference object for a given exposure assessment question across a series of questions. Users set criteria for it to be relevant to their question, and use a pre-defined set of reliability criteria. 
 
 The object is evaluated based on its data availability, precision, choice of methods, and a final score is calculated for both its relevance and reliability based on its useability at "Gold" and "Silver" levels of quality. This table collects the relevant data from non-CREED tables selected by the user or an automated data population process, the user-appraised scores, and any limitations the user chooses to comments on. In the data export process, the below functions are used to create two .CSV files: one for reliability and one for relevance.
-Scores are used to calculate a [CREED score](CREED_scores_data.htmll).
+Scores are used to calculate a [CREED score](CREED_scores_data.html).
 
 This table is not intended to be used as a final data product, but is included in the format because it provides traceability on how the CREED score was calculated. Because a large part of the evaluation logic is included in the [eData app](https://github.com/NIVANorge/STOPeData), this table is currently just a container with little relevant information. It is planned to migrate this logic to the eDataDRF in future.
 

--- a/vignettes/CREED_scores_data.qmd
+++ b/vignettes/CREED_scores_data.qmd
@@ -48,7 +48,7 @@ initialise_CREED_scores_tibble()
 Identifier for data source, foreign key referencing [reference id](references_data.html#reference-id).
 
 ## Silver Reliability
-`SILVER_RELIABILITY` - *numeric, free, mandatory*
+`SILVER_RELIABILITY` - *string, free, mandatory*
 
 Silver reliability score. See [Usability Scores](#usability-scores) for valid levels.
 

--- a/vignettes/biota_data.qmd
+++ b/vignettes/biota_data.qmd
@@ -13,7 +13,7 @@ knitr:
 
 # Introduction
 
-Where biota are sampled, it becomes important to capture considerable additional information. Species, tissue type, gender, lifestage, and other factors can considerably affect exposure to pollutants, and thus this information is important to put their occurence in its full context. 
+Where biota are sampled, it becomes important to capture considerable additional information. Species, tissue type, gender, lifestage, and other factors can considerably affect exposure to pollutants, and thus this information is important to put their occurrence in its full context.
 
 The Biota table is an intermediate table that extends the [Samples data table](samples_data.html) where biota [compartments](compartments_data.html) are selected. Otherwise, this element of the data entry workflow is skipped as irrelevant. 
 

--- a/vignettes/campaign_data.qmd
+++ b/vignettes/campaign_data.qmd
@@ -46,7 +46,7 @@ The date when a sampling campaign began; the first reported sampling date. In ra
 ## Campaign End Date
 `CAMPAIGN_END_DATE` - *date (ISO), free, optional*
 
-If avaiable, the last sampling date of the campaign.
+If available, the last sampling date of the campaign.
 
 ## Organisation
 `ORGANISATION` - *string, free, mandatory*

--- a/vignettes/measurements_data.qmd
+++ b/vignettes/measurements_data.qmd
@@ -38,7 +38,7 @@ initialise_measurements_tibble()
 ## Parameter Name
 `PARAMETER_NAME` - *string, free, mandatory*
 
-[Parameter name](parameters_data.html#parameter-name) is a foreign key that references the [Parameter data table](parameter_data.html). During Samples table creation the user selects relevant parameters using their name and type.
+[Parameter name](parameters_data.html#parameter-name) is a foreign key that references the [Parameter data table](parameters_data.html). During Samples table creation the user selects relevant parameters using their name and type.
 
 ## Sampling Date
 `SAMPLING_DATE` - *string, free, mandatory*
@@ -121,7 +121,7 @@ The sample size of a biota population and/or number of replicates the [Measured 
 
 Limit of Quantification of the method, if reported. 
 
-If no [Measured value](#measured-value) is reported, at least one of an LOQ and an LOD should be reported with value and unit; implicitly the stressor occurence was below the method's ability to quantify. If a Measured value, LOQ and/or LOQ are reported, please include as many as possible in the extracted data.
+If no [Measured value](#measured-value) is reported, at least one of an LOQ and an LOD should be reported with value and unit; implicitly the stressor occurrence was below the method's ability to quantify. If a Measured value, LOQ and/or LOD are reported, please include as many as possible in the extracted data.
 
 ## LOQ Unit
 `LOQ_UNIT` - *string, controlled, conditionally mandatory*
@@ -137,7 +137,7 @@ Uses the [Measured Unit](#measured-unit) vocabulary.
 
 Limit of Detection of the method, if reported. 
 
-If no [Measured value](#measured-value) is reported, at least one of an LOQ and an LOD should be reported with value and unit; implicitly the stressor occurence was below the method's ability to detect. If a Measured value, LOQ and/or LOQ are reported, please include as many as possible in the extracted data.
+If no [Measured value](#measured-value) is reported, at least one of an LOQ and an LOD should be reported with value and unit; implicitly the stressor occurrence was below the method's ability to detect. If a Measured value, LOQ and/or LOD are reported, please include as many as possible in the extracted data.
 
 ## LOD Unit
 `LOD_UNIT` - *string, controlled, conditionally mandatory*

--- a/vignettes/methods_data.qmd
+++ b/vignettes/methods_data.qmd
@@ -24,7 +24,7 @@ These methodologies are structured for the collection of data on chemicals stres
 
 Currently no external ontology or taxonomy is used for methodology. The [Chemical Methods Ontology](https://github.com/rsc-ontology/rsc-cmo) (CMO) may be appropriate, and we will continue to review its progress to determine the appropriate form of any harmonisation. 
 
-The Methods table is a metadata table that is transformed before being linked to the [Measurements table](measurements_data.html). Because it is assumed that each measurement will typically have a sampling, extraction, fractionation, and analytical protocol associated with it, the measurements table has a foreign key for each type of methdology that references the relevant [Protocol ID](#protocol-id).
+The Methods table is a metadata table that is transformed before being linked to the [Measurements table](measurements_data.html). Because it is assumed that each measurement will typically have a sampling, extraction, fractionation, and analytical protocol associated with it, the measurements table has a foreign key for each type of methodology that references the relevant [Protocol ID](#protocol-id).
 
 ```{r}
 #| label: setup
@@ -44,7 +44,7 @@ initialise_methods_tibble()
 
 A short, terse identifier for the protocol. This is used as a primary key for Methods data and a foreign key in the Sampling Protocol, Extraction Protocol, Fractionation Protocol, and Analytical Protocol columns.  [Measurements data](measurements_data.html). 
 
-Protocol IDs are automatically generated based on the protocol type, short name, campaign name, and, in cases where more than one of a type of technique is used per campaign, sequence number. This is theoretically vulnerable to colisions, and a hashed or serial key would be safer, but this is not anticipated to be a problem at the current scale of use at the format. Additionally, it is far easier to read and intepret for humans. 
+Protocol IDs are automatically generated based on the protocol type, short name, campaign name, and, in cases where more than one of a type of technique is used per campaign, sequence number. This is theoretically vulnerable to collisions, and a hashed or serial key would be safer, but this is not anticipated to be a problem at the current scale of use at the format. Additionally, it is far easier to read and interpret for humans.
 
 ```{r}
 #| label: protocol-id

--- a/vignettes/parameters_data.qmd
+++ b/vignettes/parameters_data.qmd
@@ -26,7 +26,7 @@ library(eDataDRF)
 initialise_parameters_tibble()
 ```
 
-It is expected that most relevant studies will be collecting data on chemical pollutants in the environment. Non-chemicals are accomodated by the format, but they cannot necessarily be as well-characterised as chemicals, where we are able to take advantage of the high-quality infrastructure developed by chemists. 
+It is expected that most relevant studies will be collecting data on chemical pollutants in the environment. Non-chemicals are accommodated by the format, but they cannot necessarily be as well-characterised as chemicals, where we are able to take advantage of the high-quality infrastructure developed by chemists. 
 
 # Variables
 

--- a/vignettes/rationale.qmd
+++ b/vignettes/rationale.qmd
@@ -16,7 +16,7 @@ knitr:
 library(eDataDRF)
 ```
 
-The eData Data Reporting Format is a format for the standardisation of data on pollutant occurence in the environment. By converting this data to a single, consistent format, it makes it easier to validate, compare, analyse, and reuse, in line with the [FAIR principles](https://www.go-fair.org/fair-principles/).
+The eData Data Reporting Format is a format for the standardisation of data on pollutant occurrence in the environment. By converting this data to a single, consistent format, it makes it easier to validate, compare, analyse, and reuse, in line with the [FAIR principles](https://www.go-fair.org/fair-principles/).
 
 # Why standardise?
 

--- a/vignettes/references_data.qmd
+++ b/vignettes/references_data.qmd
@@ -94,7 +94,7 @@ The primary instition responsible for a referenced object. Conditionally mandato
 
 ## DOI
 `DOI` - *String, free, optional*
-If available, the Digital Object Identifier associated with a reference object. Optional, but the preferred identifier when avaiable. 
+If available, the Digital Object Identifier associated with a reference object. Optional, but the preferred identifier when available.
 
 See the website of the [doi Foundation](https://www.doi.org/) for more information.
 

--- a/vignettes/samples_data.qmd
+++ b/vignettes/samples_data.qmd
@@ -43,7 +43,7 @@ initialise_samples_tibble()
 ## Parameter Name
 `PARAMETER_NAME` - *string, controlled, mandatory*
 
-[Parameter name](parameters_data.html#parameter-name) is a foreign key that references the [Parameter data table](parameter_data.html). During Samples table creation the user selects relevant parameters using their name and type.
+[Parameter name](parameters_data.html#parameter-name) is a foreign key that references the [Parameter data table](parameters_data.html). During Samples table creation the user selects relevant parameters using their name and type.
 
 ## Parameter Type
 `PARAMETER_TYPE` - *string, controlled, mandatory*
@@ -68,7 +68,7 @@ Combinations of [Environmental Compartment](compartments_data.html#environmental
 ## Sampling Date
 `SAMPLING_DATE` - *date (ISO), free, mandatory*
 
-The date a sample was taken. This should be reported to the highest degree of date precision possible (time is not needed). However, if day or month is not avaiable, it can be reported as the first day of a reported month or year. In this case, please note this in the [Measurement comment](#todo: add link) section.
+The date a sample was taken. This should be reported to the highest degree of date precision possible (time is not needed). However, if day or month is not available, it can be reported as the first day of a reported month or year. In this case, please note this in the [Measurement comment](measurements_data.html#measurement-comment) section.
 
 ## Subsample
 `SUBSAMPLE` - *string, free, mandatory*
@@ -80,16 +80,7 @@ Where a single sampling event is subsampled, use this variable to note it. In th
 
 A Subsample ID is generated for each subsample based on its identifying characteristics.
 
-Actually, no it isn't. Not used.
-
-```{r}
-
-```
-
 ## Sample ID
 `SAMPLE_ID` - *string, free, mandatory*
 
-Actually this includes subsample;
-
-#TODO
 e.g.:`DummyCampaign1997_SITE_001-Tim-Notreported-2023-02-12-R-1`


### PR DESCRIPTION
…and source

- Fix spelling: occurrence, available, individual, methodology, collisions, interpret, accommodated
- Fix broken vignette links: CREED_scores_data.htmll, parameter_data.html (x2), #todo placeholder
- Fix copy-paste error: "LOQ and/or LOQ" → "LOQ and/or LOD" (x2 in measurements_data.qmd)
- Fix SILVER_RELIABILITY type annotation: numeric → string
- Remove leftover draft text in samples_data.qmd (SUBSAMPLE_ID/SAMPLE_ID sections)
- Fix roxygen typos in fct_formats.R and fct_generate_IDs.R (propagated to man/)
- Fix test file header comment referencing wrong filename